### PR TITLE
feat: add mission intelligence controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This project was built for the Turion Hackathon 2025. The idea is to make real m
 - generates dark-theme 3D trajectory plots with Matplotlib
 - serves plots and mission search through a Flask interface
 - optionally asks Gemini to summarize mission background and significance
-- includes an additional Three.js frontend/backend experiment for interactive exploration
+- includes a Three.js mission explorer with searchable agency filters, launch sorting, and live dataset summaries
 
 ## Demo
 
@@ -43,7 +43,7 @@ mission search
                               Flask interface
 ```
 
-The main maintained prototype is in `Turion-Hackathon-2025/`. The root `backend/` and `frontend/` folders contain a separate interactive visualization experiment and are not required to run the Flask application.
+The trajectory workflow is in `Turion-Hackathon-2025/`. The root `backend/` and `frontend/` folders form a separate interactive mission explorer with a searchable mission intelligence sidebar and simplified 3D positions.
 
 ## Setup
 
@@ -106,6 +106,24 @@ python main.py
 
 Open [http://localhost:3000](http://localhost:3000), search for a mission, and wait while the application retrieves and plots remote ephemeris data.
 
+### Run the interactive mission explorer
+
+Start its API from the repository root:
+
+```bash
+cd backend
+python main.py
+```
+
+In a second terminal, serve the browser files:
+
+```bash
+cd frontend
+python -m http.server 8000
+```
+
+Open [http://localhost:8000](http://localhost:8000). The sidebar summarizes the currently visible active missions and supports free-text search, agency filters, and launch-date sorting.
+
 ## Validation
 
 No reliable automated test suite currently exists. `test_turion.py` is an exploratory script that performs network and Gemini calls; it should not yet be treated as a deterministic test.
@@ -129,7 +147,7 @@ An API credential was previously embedded in repository source. The improvement 
 - mission identification still relies on JPL-compatible search values
 - generated plots are static rather than truly interactive
 - some fallback dates and broad exception handling remain from the hackathon
-- the Three.js prototype uses simplified mission positioning in several places
+- the Three.js explorer uses simplified mission positioning in several places
 - network errors need clearer user-facing states
 
 ## Roadmap
@@ -137,7 +155,7 @@ An API credential was previously embedded in repository source. The improvement 
 - add deterministic tests for parsing Horizons responses
 - cache remote responses and avoid repeating expensive queries
 - validate mission input before generating a plot
-- unify the Flask and Three.js prototypes around one API
+- unify the trajectory and Three.js experiences around one API
 - add loading, empty, and actionable error states
 - capture a short, current demo after end-to-end validation
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -19,9 +19,34 @@
 
     <div class="container">
         <div class="sidebar">
+            <section class="mission-summary" aria-label="Mission dataset summary">
+                <div class="summary-card">
+                    <strong id="active-count">—</strong>
+                    <span>active missions</span>
+                </div>
+                <div class="summary-card">
+                    <strong id="agency-count">—</strong>
+                    <span>agency groups</span>
+                </div>
+                <div class="summary-card">
+                    <strong id="launch-span">—</strong>
+                    <span>launch span</span>
+                </div>
+            </section>
+
             <div class="filter-section">
-                <h2>Filter Missions</h2>
-                <div class="filter-options">
+                <h2>Find a Mission</h2>
+                <div class="mission-query">
+                    <label for="mission-search">Search by mission or agency</label>
+                    <input id="mission-search" type="search" placeholder="Try Voyager or ESA">
+                    <label for="mission-sort">Sort missions</label>
+                    <select id="mission-sort">
+                        <option value="name">Name A–Z</option>
+                        <option value="newest">Newest launch</option>
+                        <option value="oldest">Oldest launch</option>
+                    </select>
+                </div>
+                <div class="filter-options" aria-label="Filter by agency">
                     <label>
                         <input type="checkbox" class="mission-filter" data-agency="NASA" checked> NASA
                     </label>

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -443,6 +443,7 @@ async function fetchMissionPosition(missionId) {
             // Add to solar system
             solarSystem.add(missionObject);
             missionObjects[missionId] = missionObject;
+            missionObject.visible = getMissionView().some(item => item.id === missionId);
             
             // Fetch trajectory
             fetchMissionTrajectory(missionId);
@@ -497,42 +498,104 @@ async function fetchMissionTrajectory(missionId) {
     }
 }
 
-// Populate the missions list in the sidebar
+// Build the mission view from search, sort, and agency filters
+function selectedAgencies() {
+    return Array.from(document.querySelectorAll('.mission-filter:checked'))
+        .map(checkbox => checkbox.dataset.agency);
+}
+
+function missionMatchesAgency(mission, agencies) {
+    return agencies.some(agency => {
+        if (agency === 'other') {
+            return !mission.agency.includes('NASA') && !mission.agency.includes('ESA');
+        }
+        return mission.agency.includes(agency);
+    });
+}
+
+function getMissionView() {
+    const query = document.getElementById('mission-search').value.trim().toLowerCase();
+    const sort = document.getElementById('mission-sort').value;
+    const agencies = selectedAgencies();
+
+    const view = missions.filter(mission => {
+        if (mission.status !== 'Active' || !missionMatchesAgency(mission, agencies)) {
+            return false;
+        }
+        const searchable = `${mission.name} ${mission.agency} ${mission.description}`.toLowerCase();
+        return !query || searchable.includes(query);
+    });
+
+    view.sort((a, b) => {
+        if (sort === 'newest') return b.launch_date.localeCompare(a.launch_date);
+        if (sort === 'oldest') return a.launch_date.localeCompare(b.launch_date);
+        return a.name.localeCompare(b.name);
+    });
+    return view;
+}
+
+function renderMissionSummary(view) {
+    const years = view
+        .map(mission => Number(mission.launch_date.slice(0, 4)))
+        .filter(Number.isFinite);
+    const agencies = new Set(view.map(mission => mission.agency));
+
+    document.getElementById('active-count').textContent = view.length;
+    document.getElementById('agency-count').textContent = agencies.size;
+    document.getElementById('launch-span').textContent = years.length
+        ? `${Math.min(...years)}–${Math.max(...years)}`
+        : '—';
+}
+
+function updateMissionVisibility(view) {
+    const visibleIds = new Set(view.map(mission => mission.id));
+    missions.forEach(mission => {
+        const missionObject = missionObjects[mission.id];
+        if (missionObject) {
+            missionObject.visible = visibleIds.has(mission.id);
+        }
+    });
+}
+
+// Populate the searchable mission list and summary
 function populateMissionsList() {
     const missionsList = document.getElementById('missions-list');
+    const view = getMissionView();
     missionsList.innerHTML = '';
-    
+    renderMissionSummary(view);
+
     if (missions.length === 0) {
         missionsList.innerHTML = '<div class="error">No missions found.</div>';
         return;
     }
-    
-    // Get the mission item template
+
+    if (view.length === 0) {
+        missionsList.innerHTML = '<div class="empty-state">No active missions match these filters. Try another search or agency.</div>';
+        updateMissionVisibility(view);
+        return;
+    }
+
     const template = document.getElementById('mission-item-template');
-    
-    missions.forEach(mission => {
-        if (mission.status === "Active") {
-            // Clone the template
-            const clone = document.importNode(template.content, true);
-            
-            // Set the mission data
-            const missionItem = clone.querySelector('.mission-item');
-            missionItem.dataset.id = mission.id;
-            
-            const missionName = clone.querySelector('.mission-name');
-            missionName.textContent = mission.name;
-            
-            const missionAgency = clone.querySelector('.mission-agency');
-            missionAgency.textContent = mission.agency;
-            
-            // Add click event
-            missionItem.addEventListener('click', () => {
-                selectMission(mission.id);
-            });
-            
-            missionsList.appendChild(clone);
+    view.forEach(mission => {
+        const clone = document.importNode(template.content, true);
+        const missionItem = clone.querySelector('.mission-item');
+        missionItem.dataset.id = mission.id;
+
+        clone.querySelector('.mission-name').textContent = mission.name;
+        clone.querySelector('.mission-agency').textContent =
+            `${mission.agency} · launched ${mission.launch_date.slice(0, 4)}`;
+
+        if (selectedMission?.id === mission.id) {
+            missionItem.classList.add('active');
         }
+
+        missionItem.addEventListener('click', () => {
+            selectMission(mission.id);
+        });
+        missionsList.appendChild(clone);
     });
+
+    updateMissionVisibility(view);
 }
 
 // Select a mission and show its details
@@ -628,20 +691,18 @@ function showMissionDetails(mission) {
 
 // Setup event listeners
 function setupEventListeners() {
-    // Filter missions by agency
-    const filterCheckboxes = document.querySelectorAll('.mission-filter');
-    filterCheckboxes.forEach(checkbox => {
-        checkbox.addEventListener('change', filterMissions);
+    document.querySelectorAll('.mission-filter').forEach(checkbox => {
+        checkbox.addEventListener('change', populateMissionsList);
     });
-    
-    // Reset view button
+    document.getElementById('mission-search').addEventListener('input', populateMissionsList);
+    document.getElementById('mission-sort').addEventListener('change', populateMissionsList);
+
     document.getElementById('reset-view').addEventListener('click', () => {
         camera.position.set(0, 100, 200);
         controls.target.set(0, 0, 0);
         controls.update();
     });
-    
-    // Toggle orbits button
+
     document.getElementById('toggle-orbits').addEventListener('click', () => {
         showOrbits = !showOrbits;
         scene.traverse(object => {
@@ -650,66 +711,15 @@ function setupEventListeners() {
             }
         });
     });
-    
-    // Zoom controls
+
     document.getElementById('zoom-in').addEventListener('click', () => {
         camera.position.multiplyScalar(0.8);
         controls.update();
     });
-    
+
     document.getElementById('zoom-out').addEventListener('click', () => {
         camera.position.multiplyScalar(1.2);
         controls.update();
-    });
-}
-
-// Filter missions by agency
-function filterMissions() {
-    const activeAgencies = [];
-    const filterCheckboxes = document.querySelectorAll('.mission-filter');
-    
-    // Collect active filters
-    filterCheckboxes.forEach(checkbox => {
-        if (checkbox.checked) {
-            activeAgencies.push(checkbox.dataset.agency);
-        }
-    });
-    
-    // Apply filters to mission list
-    const missionItems = document.querySelectorAll('.mission-item');
-    missionItems.forEach(item => {
-        const missionId = item.dataset.id;
-        const mission = missions.find(m => m.id === missionId);
-        
-        if (mission) {
-            const agency = mission.agency;
-            // Check if the mission agency is in the active filters
-            // For combined agencies like NASA/ESA, check if any part matches
-            const shouldShow = activeAgencies.some(activeAgency => {
-                if (activeAgency === 'other') {
-                    return !agency.includes('NASA') && !agency.includes('ESA');
-                }
-                return agency.includes(activeAgency);
-            });
-            
-            item.style.display = shouldShow ? 'flex' : 'none';
-        }
-    });
-    
-    // Update mission object visibility in the visualization
-    missions.forEach(mission => {
-        const missionObject = missionObjects[mission.id];
-        if (missionObject) {
-            const agency = mission.agency;
-            const shouldShow = activeAgencies.some(activeAgency => {
-                if (activeAgency === 'other') {
-                    return !agency.includes('NASA') && !agency.includes('ESA');
-                }
-                return agency.includes(activeAgency);
-            });
-            
-            missionObject.visible = shouldShow;
-        }
     });
 }
 

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -335,3 +335,94 @@ footer {
         right: 0.5rem;
     }
 }
+
+
+/* Mission intelligence controls */
+.mission-summary {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 8px;
+    margin-bottom: 1rem;
+}
+
+.summary-card {
+    min-width: 0;
+    padding: 12px 10px;
+    border: 1px solid rgba(143, 148, 251, 0.35);
+    border-radius: 8px;
+    background: linear-gradient(145deg, rgba(78, 84, 200, 0.35), rgba(24, 24, 43, 0.78));
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.22);
+}
+
+.summary-card strong {
+    display: block;
+    color: #ffffff;
+    font-size: 1.2rem;
+    line-height: 1.1;
+}
+
+.summary-card span {
+    display: block;
+    margin-top: 5px;
+    color: #b8baf1;
+    font-size: 0.68rem;
+    line-height: 1.25;
+}
+
+.mission-query {
+    display: grid;
+    gap: 7px;
+    margin-bottom: 14px;
+}
+
+.mission-query label {
+    color: #c9caff;
+    font-size: 0.72rem;
+    font-weight: 700;
+}
+
+.mission-query input,
+.mission-query select {
+    width: 100%;
+    min-height: 40px;
+    padding: 9px 11px;
+    color: #ffffff;
+    border: 1px solid rgba(143, 148, 251, 0.55);
+    border-radius: 6px;
+    background: rgba(17, 17, 34, 0.82);
+    font: inherit;
+}
+
+.mission-query input:focus-visible,
+.mission-query select:focus-visible {
+    outline: 2px solid #8f94fb;
+    outline-offset: 2px;
+}
+
+.mission-query input::placeholder {
+    color: #8e90ad;
+}
+
+.filter-options {
+    flex-wrap: wrap;
+}
+
+.empty-state {
+    padding: 18px 12px;
+    color: #b8baf1;
+    line-height: 1.5;
+    text-align: center;
+}
+
+@media (max-width: 560px) {
+    .mission-summary {
+        grid-template-columns: 1fr;
+    }
+
+    .summary-card {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 12px;
+    }
+}


### PR DESCRIPTION
## Summary
- Add searchable, sortable mission discovery to the Three.js explorer.
- Add live summary cards for visible missions, agency groups, and launch span.
- Keep filters synchronized with both the mission list and 3D objects.

## Progression
- Previous state: active missions could only be toggled by broad agency checkboxes.
- New state: the explorer behaves like a compact mission-intelligence dashboard.
- Next unlock or recommended follow-up: unify the trajectory and Three.js experiences behind one API.

## Changes
- Add text search and name/launch-date sorting.
- Add responsive mission summary cards and polished empty states.
- Rebuild the list from a single filtered view and keep scene visibility synchronized.
- Document how to run the interactive frontend and backend together.

## Impact
- Added: mission discovery and dataset summaries.
- Improved: portfolio value around data exploration and front-end state.
- Unchanged: simplified 3D mission positions and external ephemeris calls.

## Verification
- [x] Lint/type-check — `node --check frontend/main.js`
- [x] Build — Python modules compiled
- [x] Automated tests — mission JSON parsed successfully
- [ ] Manual behavior check — live JPL/network workflow was not exercised

## Risks and Trade-offs
- Search summaries reflect the bundled mission dataset, not live mission-status updates.
- 3D positions remain educational approximations.

## Reviewer Focus
Review the single filtered mission view and scene visibility synchronization.

## Follow-ups
- Add browser tests for search/filter combinations.
- Consolidate the two prototype backends.